### PR TITLE
Automatic documentation deployment to GitHub Pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,49 @@
+name: Deploy documentation
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "feature/documentation-auto-deployment"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Build job
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: swift-actions/setup-swift@v1
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v1
+      - name: Build DocC documentation
+        run: swift package --allow-writing-to-directory ./docs generate-documentation --target ValidationKit --transform-for-static-hosting --hosting-base-path ValidationKit --output-path ./docs
+      - name: Upload artifact
+        uses: mbernson/upload-pages-artifact@main
+        with:
+          path: ./docs
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
+    - uses: swift-actions/setup-swift@v1
     - uses: actions/checkout@v3
     - name: Build
       run: swift build -v

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.xcodeproj
 xcuserdata/
 .swiftpm
+/docs

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.6
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -11,6 +11,9 @@ let package = Package(
       name: "ValidationKit",
       targets: ["ValidationKit"]
     ),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/Sources/ValidationKit/Documentation.docc/ValidationKit.md
+++ b/Sources/ValidationKit/Documentation.docc/ValidationKit.md
@@ -1,0 +1,32 @@
+# ``ValidationKit``
+
+A lightweight Swift library for validating user input, for example in forms.
+
+## Overview
+
+Using ValidationKit, you can easily combine different input validations together.
+For example, to validate a Tweet body, you could write:
+
+```swift
+import ValidationKit
+
+// Validators can be combined using the operators `&&` and `||`
+let tweetValidator: Validator = .notEmpty && .maxLength(280)
+
+let tweet = "Hello, world!"
+let result = tweetValidator.validate(input: tweet)
+
+switch result {
+case .valid(let value):
+  print("Tweet '\(value)' is valid")
+case .invalid(let error):
+  print(String(format: "Tweet did not validate: %@", error.localizedDescription))
+}
+```
+
+## Topics
+
+### Getting Started
+
+- <doc:GettingStarted>
+- <doc:CustomValidators>


### PR DESCRIPTION
Needs Xcode 14, because we need the `DOCC_HOSTING_BASE_PATH` option.

See talk: [What's new in Swift-DocC - WWDC22 - Videos - Apple Developer](https://developer.apple.com/wwdc22/110368)